### PR TITLE
Add codeclimate config

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,7 @@
+engines:
+  csslint:
+    enabled: false
+  eslint:
+    enabled: true
+    channel: "eslint-4"
+    config: ".eslintrc.js"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "gulp": "^3.9.1",
     "gulp-eslint": "^4.0.0",
+    "gulp-util": "^3.0.8",
     "gulp-watch": "^4.3.11",
     "gutil": "^1.6.4",
     "url-loader": "^0.5.8"


### PR DESCRIPTION
Using eslint-4 engine for eslint and disable css-lint (we use sass-lint which unfortunatelly doesn't work with codeclimate ([sass-lint#9](https://github.com/sasstools/sass-lint/issues/9)).